### PR TITLE
Allow user to delete news-link

### DIFF
--- a/src/components/deleteForm.jsx
+++ b/src/components/deleteForm.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import { Mutation } from 'react-apollo';
+
+import { DELETE_LINK, FEED_QUERY } from '../graphql';
+import { Button } from '.';
+
+export default class DeleteForm extends Component {
+  updateState = (store, { data: { deleteLink } }) => {
+    const { feed } = store.readQuery({ query: FEED_QUERY });
+    store.writeQuery({
+      query: FEED_QUERY,
+      data: {
+        feed: {
+          ...feed,
+          links: feed.links.filter(item => item.id !== deleteLink.id),
+        },
+      },
+    });
+  };
+
+  render() {
+    const { id, deleteAction } = this.props;
+    return (
+      <div className="delete-form">
+        <i className="fa fa-exclamation-circle" />
+        <h3>Are you sure?</h3>
+        <p>You won't be able to revert this!</p>
+        <Mutation
+          mutation={DELETE_LINK}
+          errorPolicy="all"
+          variables={{ id }}
+          update={this.updateState}
+        >
+          {deleteLink => (
+            <Button
+              action={() => deleteAction(deleteLink)}
+              text="Delete"
+              css="btn-primary fa fa-trash createLink"
+            />
+          )}
+        </Mutation>
+      </div>
+    );
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,9 +2,11 @@ import button, { ModalButton as modalButton } from './button';
 import formGroup from './formGroup';
 import socialAuths from './socialAuths';
 import modal from './modal';
+import deleteForm from './deleteForm';
 
 export const Button = button;
 export const ModalButton = modalButton;
 export const FormGroup = formGroup;
 export const SocialAuths = socialAuths;
 export const Modal = modal;
+export const DeleteForm = deleteForm;

--- a/src/components/modal.jsx
+++ b/src/components/modal.jsx
@@ -4,7 +4,7 @@ import Button from './button';
 const Modal = (props) => {
   const { title, id, render } = props;
   return (
-    <div className="modal fade" id={id} tabIndex="-1" role="dialog" aria-hidden="true">
+    <div className="modal fade in" id={id} tabIndex="-1" role="dialog" aria-hidden="true">
       <div className="modal-dialog modal-dialog-centered" role="document">
         <div className="modal-content">
           <div className="modal-header">

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,4 +1,4 @@
-import { createLink, signup, login, updateLink } from './mutations';
+import { createLink, signup, login, updateLink, deleteLink } from './mutations';
 import { getFeed } from './queries';
 
 export const CREATE_LINK = createLink;
@@ -6,3 +6,4 @@ export const FEED_QUERY = getFeed;
 export const SIGNUP = signup;
 export const LOGIN = login;
 export const UPDATE_LINK = updateLink;
+export const DELETE_LINK = deleteLink;

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -1,13 +1,26 @@
 import gql from 'graphql-tag';
 
 export const createLink = gql`
-  mutation PostMutation($title: String!, $description: String!, $url: String!, $imageUrl: String!) {
-    postLink(title: $title, description: $description, url: $url, imageUrl: $imageUrl) {
+  mutation PostMutation(
+    $title: String!
+    $description: String!
+    $url: String!
+    $imageUrl: String!
+    $imagePublicId: String!
+  ) {
+    postLink(
+      title: $title
+      description: $description
+      url: $url
+      imageUrl: $imageUrl
+      imagePublicId: $imagePublicId
+    ) {
       id
       title
       description
       url
       imageUrl
+      imagePublicId
       createdAt
     }
   }
@@ -20,14 +33,31 @@ export const updateLink = gql`
     $description: String
     $url: String
     $imageUrl: String
+    $imagePublicId: String
   ) {
-    updateLink(id: $id, title: $title, description: $description, url: $url, imageUrl: $imageUrl) {
+    updateLink(
+      id: $id
+      title: $title
+      description: $description
+      url: $url
+      imageUrl: $imageUrl
+      imagePublicId: $imagePublicId
+    ) {
       id
       title
       description
       url
       imageUrl
+      imagePublicId
       createdAt
+    }
+  }
+`;
+
+export const deleteLink = gql`
+  mutation DeleteLink($id: ID!) {
+    deleteLink(id: $id) {
+      id
     }
   }
 `;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -10,6 +10,7 @@ export const getFeed = gql`
         description
         url
         imageUrl
+        imagePublicId
         createdAt
       }
     }

--- a/src/modules/linkForm.jsx
+++ b/src/modules/linkForm.jsx
@@ -24,9 +24,9 @@ export default class LinkForm extends React.Component {
 
   render() {
     const { state, filePath, handleImageSelect, handleChange, submitForm } = this.props;
-    const { id, title, description, url, imageUrl, image, spinner, edit, disable } = state;
-    let data = { title, description, url, imageUrl };
-    data = edit ? { id, ...data } : data;
+    const { id, image, spinner, edit, disable, file, imageUrl, imagePublicId, ...linkData } = state;
+    let data = edit ? { id, ...linkData } : { imageUrl, imagePublicId, ...linkData };
+    if (edit) data = file === '' ? data : { imageUrl, imagePublicId, ...data };
     return (
       <Mutation mutation={type[edit]} errorPolicy="all" variables={data} update={this.updateState}>
         {mutationAction => (
@@ -36,7 +36,7 @@ export default class LinkForm extends React.Component {
                 <img className="link-dp" src={image.length ? image : imageIcon} alt="link-icon" />
               </div>
               <div className="col-sm-8">
-                {linkFormInputs(title, url, filePath).map(input => (
+                {linkFormInputs(linkData.title, linkData.url, filePath).map(input => (
                   <React.Fragment key={input.key}>
                     {input.text}
                     <FormGroup
@@ -58,7 +58,7 @@ export default class LinkForm extends React.Component {
                     onChange={handleChange}
                     className="form-control"
                     aria-label="With textarea"
-                    value={description}
+                    value={linkData.description}
                   />
                 </div>
                 <Button

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,11 +1,6 @@
-body,
-html {
-  height: 100%;
-}
-
 .background {
   background-image: url("../images/news-link.jpg");
-  height: 100%;
+  height: 100vh;
   background-color: rgb(26, 37, 74);
   background-position: center;
   background-repeat: no-repeat;
@@ -14,7 +9,7 @@ html {
 
 div.transbox {
   background-color: #fcfcfdc7; /* or #bdc1d212 */
-  height: 100%;
+  min-height: 100vh;
   color: white;
 }
 .home-text {
@@ -176,23 +171,6 @@ body {
   margin-top: 1em;
 }
 
-.masonry {
-  display: flex;
-  flex-flow: row wrap;
-  margin-left: -8px; /* Adjustment for the gutter */
-  width: 100%;
-  padding-bottom: 1.5em;
-  background-color: #c6ccd4;
-  padding-left: 1.5em;
-  margin-top: 6em;
-}
-
-.masonry-brick {
-  flex: auto;
-  width: 250px;
-  margin: 0.5em;
-}
-
 .input-group .fa {
   color: black;
   padding: 0.4em;
@@ -238,11 +216,6 @@ form {
 .card-title {
   margin-top: 0.3em;
 }
-@media screen and (max-width: 575px) {
-  .home-text {
-    display: none;
-  }
-}
 .signup-link {
   margin-top: 1em;
   color: white;
@@ -276,4 +249,60 @@ form {
 
 .fixed-top.nav-tabs {
   top: 56px;
+}
+
+.delete-form {
+  color: black;
+  text-align: center;
+}
+
+.fa-exclamation-circle {
+  font-size: 4.5em;
+  color: darkorange;
+}
+@media screen and (max-width: 575px) {
+  .home-text {
+    display: none;
+  }
+  .feature {
+    max-width: none;
+    width: 100%;
+  }
+  .card-img-top {
+    height: auto;
+  }
+}
+
+@media screen and (min-width: 576px) {
+  .card-img-top {
+    height: 200px;
+  }
+}
+
+.feature {
+  -webkit-box-shadow: 0 2px 50px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 50px rgba(0, 0, 0, 0.08);
+  margin-bottom: 30px;
+  background: #fff;
+  display: table;
+  border-radius: 5px;
+}
+.row.news-links {
+  margin: auto;
+  margin-top: 6em;
+  padding-top: 1em;
+}
+
+.error-template {
+  padding: 40px 15px;
+  text-align: center;
+  color: black;
+  padding-top: 12em;
+}
+.error-actions {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+.error-actions .btn {
+  margin-right: 10px;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,15 +70,21 @@ export const linkImageData = (file, publicId) => ({
   public_id: publicId,
 });
 
-export const errorObject = ({ errors, graphQLErrors }) => ({
+const unauthoried = 'Unauthorized, please login!';
+const errorMessages = {
+  'invalid signature': unauthoried,
+  'GraphQL error: invalid signature': unauthoried,
+};
+
+export const errorObject = ({ errors, graphQLErrors, message: errMessage }) => ({
   errors: () => errors.forEach((errorMessage) => {
     toastr.error(errorMessage);
   }),
-  response: () => toastr.error('Invalid image file'),
+  response: () => toastr.error(errMessage),
   graphQLErrors: () => {
     const { data, message } = graphQLErrors[0];
     if (data) return Object.values(data).forEach(instance => toastr.error(instance.message));
-    return toastr.error(message);
+    return toastr.error(errorMessages[message] || message);
   },
 });
 


### PR DESCRIPTION
#### What does this PR do?
Allow user to delete news-link with cloudinary image also deleted

#### Description of Task completed?
- handle unauthorized error on link delete
- define DeleteForm mutation component to handle link deletion
- define `DELETE_LIINK` mutation schema
- include imagePublicId to link model to be able to delete link-image
- refactor card and server error UIs for better UX

#### How should this be manually tested?
1. On your browser, go to: `http://localhost:3000/links`
2. Click on delete icon on any news-link
3. Click `delete` button in confirm modal
4. Confirm that the link was deleted and removed from DOM
5. Refresh the page to confirm that the removed link does not reappear
6. Login to cloudinary account to confirm that the deleted link's image was also deleted

#### Screenshots (if Available)
<img width="814" alt="Screen Shot 2019-03-24 at 11 57 40 PM" src="https://user-images.githubusercontent.com/29695968/54887217-a9a60e00-4e90-11e9-82fb-802073dd3d79.png">
